### PR TITLE
Fix Navigation to Custom Metadata Objects in Lightning

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -51,8 +51,8 @@ var parseSetupTree = (response, url)=>{
 	return commands
 }
 var parseMetadata = (data, url)=>{
+	if (data.length == 0 || typeof data.sobjects == "undefined") return false
 	let commands = {}
-	if(data.length == 0 || typeof data.sobjects == "undefined") return false
 	let labelPlural, label, name, keyPrefix
 	data.sobjects.map(obj => {
 		if(obj.keyPrefix != null) {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -56,8 +56,12 @@ var parseMetadata = (data, url)=>{
 		if (!keyPrefix) {
 			return commands
 		}
-		commands['List ' + labelPlural] = { key: name, keyPrefix: keyPrefix, url: url + '/' + keyPrefix }
-		commands['New ' + label] = { key: name, keyPrefix: keyPrefix, url: url + '/' + keyPrefix + '/e' }
+		let baseUrl = "/";
+		if (url.includes("lightning.force") && name.endsWith("__mdt")) {
+			baseUrl += "lightning/setup/CustomMetadata/page?address=";
+		}
+		commands["List " + labelPlural] = { key: name, keyPrefix, url: `${baseUrl}/${keyPrefix}` }
+		commands["New " + label] = { key: name, keyPrefix, url: `${baseUrl}/${keyPrefix}/e` }
 		return commands
 	}, {})
 }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -52,15 +52,14 @@ var parseSetupTree = (response, url)=>{
 }
 var parseMetadata = (data, url)=>{
 	if (data.length == 0 || typeof data.sobjects == "undefined") return false
-	let commands = {}
-	data.sobjects.map(obj => {
-		if(obj.keyPrefix != null) {
-			({labelPlural, label, name, keyPrefix} = obj)
+	return data.sobjects.reduce((commands, obj) => {
+		if (obj.keyPrefix != null) {
+			({ labelPlural, label, name, keyPrefix } = obj)
 			commands['List ' + labelPlural] = { key: name, keyPrefix: keyPrefix, url: url + '/' + keyPrefix }
 			commands['New ' + label] = { key: name, keyPrefix: keyPrefix, url: url + '/' + keyPrefix + '/e' }
 		}
-	})
-	return commands
+		return commands
+	}, {})
 }
 var parseCustomObjects = (response, url)=>{
 	let commands = {}

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -53,7 +53,6 @@ var parseSetupTree = (response, url)=>{
 var parseMetadata = (data, url)=>{
 	if (data.length == 0 || typeof data.sobjects == "undefined") return false
 	let commands = {}
-	let labelPlural, label, name, keyPrefix
 	data.sobjects.map(obj => {
 		if(obj.keyPrefix != null) {
 			({labelPlural, label, name, keyPrefix} = obj)

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -53,10 +53,11 @@ var parseSetupTree = (response, url)=>{
 var parseMetadata = (data, url)=>{
 	if (data.length == 0 || typeof data.sobjects == "undefined") return false
 	return data.sobjects.reduce((commands, { labelPlural, label, name, keyPrefix }) => {
-		if (obj.keyPrefix != null) {
-			commands['List ' + labelPlural] = { key: name, keyPrefix: keyPrefix, url: url + '/' + keyPrefix }
-			commands['New ' + label] = { key: name, keyPrefix: keyPrefix, url: url + '/' + keyPrefix + '/e' }
+		if (!keyPrefix) {
+			return commands
 		}
+		commands['List ' + labelPlural] = { key: name, keyPrefix: keyPrefix, url: url + '/' + keyPrefix }
+		commands['New ' + label] = { key: name, keyPrefix: keyPrefix, url: url + '/' + keyPrefix + '/e' }
 		return commands
 	}, {})
 }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -52,9 +52,8 @@ var parseSetupTree = (response, url)=>{
 }
 var parseMetadata = (data, url)=>{
 	if (data.length == 0 || typeof data.sobjects == "undefined") return false
-	return data.sobjects.reduce((commands, obj) => {
+	return data.sobjects.reduce((commands, { labelPlural, label, name, keyPrefix }) => {
 		if (obj.keyPrefix != null) {
-			({ labelPlural, label, name, keyPrefix } = obj)
 			commands['List ' + labelPlural] = { key: name, keyPrefix: keyPrefix, url: url + '/' + keyPrefix }
 			commands['New ' + label] = { key: name, keyPrefix: keyPrefix, url: url + '/' + keyPrefix + '/e' }
 		}


### PR DESCRIPTION
Currently, the extension will take you into Classic whenever you navigate to a custom metadata object list or new. Hoping Salesforce fixes this at some point, but in the meantime we can just modify the path slightly to stay in Lightning.

I also refactored some other areas of `parseMetadata` in the interest of simplifying the logic I added.

Tested in Chrome and Firefox from both Lightning and Classic.