### PR TITLE
fix #35 -  Getting "null" text in final URL for some core functions

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -125,7 +125,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse)=>{
 					{"Authorization": "Bearer " + request.sessionId, "Accept": "application/json"})
 					.then(response => {
 						// TODO good place to filter out unwanted objects
-						metaData[request.sessionHash] = parseMetadata(response, request.domain, request.settings)
+						metaData[request.sessionHash] = parseMetadata(response, request.domain, request.settings,request.serverUrl)
 						sendResponse(metaData[request.sessionHash])
 					}).catch(e=>_d(e))
 			else

--- a/src/background.js
+++ b/src/background.js
@@ -38,7 +38,7 @@ const getOtherExtensionCommands = (otherExtension, requestDetails, settings = {}
 	}
 }
 
-const parseMetadata = (data, url, settings, serverUrl = {})=>{
+const parseMetadata = (data, url, settings = {}, serverUrl)=>{
 	if (data.length == 0 || typeof data.sobjects == "undefined") return false
 	let mapKeys = Object.keys(forceNavigator.objectSetupLabelsMap)
 	return data.sobjects.reduce((commands, sObjectData) => forceNavigator.createSObjectCommands(commands, sObjectData, serverUrl), {})

--- a/src/background.js
+++ b/src/background.js
@@ -38,10 +38,10 @@ const getOtherExtensionCommands = (otherExtension, requestDetails, settings = {}
 	}
 }
 
-const parseMetadata = (data, url, settings = {})=>{
+const parseMetadata = (data, url, settings, serverUrl = {})=>{
 	if (data.length == 0 || typeof data.sobjects == "undefined") return false
 	let mapKeys = Object.keys(forceNavigator.objectSetupLabelsMap)
-	return data.sobjects.reduce((commands, sObjectData) => forceNavigator.createSObjectCommands(commands, sObjectData), {})
+	return data.sobjects.reduce((commands, sObjectData) => forceNavigator.createSObjectCommands(commands, sObjectData, serverUrl), {})
 }
 
 const goToUrl = (targetUrl, newTab, settings = {})=>{

--- a/src/shared.js
+++ b/src/shared.js
@@ -325,7 +325,7 @@ export const forceNavigator = {
 			console.info('err',e)
 		}
 	},
-	"createSObjectCommands": (commands, sObjectData) => {
+	"createSObjectCommands": (commands, sObjectData, serverUrl) => {
 		const { labelPlural, label, name, keyPrefix } = sObjectData
 		const mapKeys = Object.keys(forceNavigator.objectSetupLabelsMap)
 		if (!keyPrefix || forceNavigatorSettings.skipObjects.includes(keyPrefix)) { return commands }
@@ -342,7 +342,7 @@ export const forceNavigator = {
 			"label": t("prefix.new") + " " + label
 		}
 		if(forceNavigatorSettings.lightningMode) {
-			let targetUrl = forceNavigator.serverUrl + "/lightning/setup/ObjectManager/" + name
+			let targetUrl = serverUrl + "/lightning/setup/ObjectManager/" + name
 			mapKeys.forEach(key=>{
 				commands[keyPrefix + "." + key] = {
 					"key": keyPrefix + "." + key,
@@ -567,6 +567,7 @@ export const forceNavigator = {
 				"key": forceNavigator.organizationId,
 				"force": force,
 				"sessionId": forceNavigator.sessionId,
+				"serverUrl" : forceNavigator.serverUrl,
 				"action": "getMetadata"
 			}
 			chrome.runtime.sendMessage(options, response=>Object.assign(forceNavigator.commands, response))


### PR DESCRIPTION
Due to race condition, createSObjectCommands() that runs in the background, sometimes has no access to forceNavigator.serverUrl (as this value is set in the contentScript).

To fix it, I passed the value of serverUrl in the "getMetaData" message, in a similar way apiUrl and other values are passed.
The result is that the error is not happening anymore.