### PR TITLE
Adding search ability

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Salesforce Navigator for Lightning",
-	"version": "4.8.20",
+	"version": "4.8.20.1",
 	"manifest_version": 2,
 	"description": "Get more done in Salesforce - list and search records, make new ones, create a task or login as on the fly!",
 	"page_action": {

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -80,6 +80,12 @@
 	font-size: 16px;
 	text-decoration: none;
 }
+.sfnav_child_smaller {
+	font-size: 14px;
+}
+.sfnav_child_extra_small {
+	font-size: 10px;
+}
 #sfnavSearchBox input {
 	position: relative;
 	flex: 1;

--- a/src/background.js
+++ b/src/background.js
@@ -65,8 +65,8 @@ const loadCompactLayoutForSobject = (sobject,options,compactLayoutFieldsForSobje
 const doSearch = (searchQuery,options,sendResponse,labelToNameFieldMapping,labelToSobjectApiNameMapping,compactLayoutFieldsForSobject) => {
 	
 	//clean and identift what is searched:  What is the Sobject and what is the query
+	searchQuery = searchQuery.replace(/^\?\s*/,'')
 	let searchQueryArray = searchQuery.split(/([^\s"]+|"[^"]*")+/g).filter(value => (value != ' ' && value != ''));
-	searchQueryArray.shift() //remove the ?
 	let searchSobject=searchQueryArray[0]?.replaceAll('"','')
 	let lc_searchSobject = searchSobject.toLowerCase()
 	searchQueryArray.shift() //remove the sobject
@@ -166,7 +166,7 @@ const getMoreData = (sourceCommand,options,sendResponse)=>{
 	forceNavigator.getHTTP(url,"json", {"Authorization": "Bearer " + options.sessionId, "Accept": "application/json"})
 	.then(response => {
 		if(response && response.error) { console.error("response", response, chrome.runtime.lastError); return }
-		//console.info("Resposne:`n", response)
+		console.info("Resposne:`n", response)
 		let i = 0
 
 		//use the "processResponse" for this object type, to generate the list of commands

--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -13,6 +13,7 @@ module.exports = {
 		"settings.theme": "Theme",
 		"settings.useApiName": "Show API Name",
 		"commands.home": "Home",
+		"commands.help": "Help",
 		"commands.setup": "Setup",
 		"commands.mergeAccounts": "Merge Accounts",
 		"commands.toggleAllCheckboxes": "Toggle All Checkboxes",
@@ -250,5 +251,10 @@ module.exports = {
 		"setup.emailOutlookSync": "Email > Outlook Integration and Sync",
 		"setup.emailExternalService": "Email > Send through External Email Services",
 		"setup.emailTestDeliverability": "Email > Test Deliverability",
+		"report.runReport" : "Run Report",
+		"report.editReport" : "Edit Report",
+		"commands.logout" : "Logout",
+		"moreData.permissionSetsInGroup" : "Permission Sets in Group",
+		"moreData.objectSettings" : "Object Settings"
 	},
 }

--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -251,6 +251,7 @@ module.exports = {
 		"setup.emailOutlookSync": "Email > Outlook Integration and Sync",
 		"setup.emailExternalService": "Email > Send through External Email Services",
 		"setup.emailTestDeliverability": "Email > Test Deliverability",
+		"setup.territoryModels" : "Territory Models",
 		"report.runReport" : "Run Report",
 		"report.editReport" : "Edit Report",
 		"commands.logout" : "Logout",

--- a/src/shared.js
+++ b/src/shared.js
@@ -1887,6 +1887,10 @@ export const forceNavigator = {
 			"lightning":"/lightning/setup/TestEmailDeliverability/home",
 			"classic":""
 		},
+		"setup.territoryModels": {
+			"lightning":"/lightning/setup/Territory2Models/home",
+			"classic":"/ui/setup/territory2/Territory2ModelListPage?setupid=Territory2Models"
+		},
 		"report.runReport": {
 			"lightning":"/lightning/o/Report/home",
 			"classic":"/00O/o"

--- a/src/shared.js
+++ b/src/shared.js
@@ -118,11 +118,12 @@ export const ui = {
 	//lookupMode decides what is displayed in the dropdown (command completion, help text, or search resutls)
 	"lookupMode": LOOKUP_MODE_SHOW_COMMANDS,   //Default is to show command completion	
 	"lookupCommands": ()=>{
-		const input = ui.quickSearch.value
+		let input = ui.quickSearch.value
 
 		ui.clearOutput()
 		//if(input.substring(0,1) == "?") ui.addSearchResult("menu.globalSearch")
 		if(input.substring(0,1) == "?") {
+			input = input.replace(/^\?\s*/,'')
 			//Handle search.
 			//Syntax - ? sobject value
 			//example: ? account sony
@@ -137,18 +138,18 @@ export const ui = {
 			let searchQuery = input.split(/([^\s"]+|"[^"]*")+/g).filter(value => (value != ' ' && value != ''));
 
 			switch(searchQuery.length) {
-				case 1:
+				case 0:
 					//Only "?" entered
 					ui.lookupMode = LOOKUP_MODE_SHOW_COMMANDS
 					break
-				case 2:
-					//2 elements - "?" and a sobject
+				case 1:
+					//1 element after the "?" --> a sobject
 					ui.lookupMode = LOOKUP_MODE_COMPLETE_OBJECT_NAME
 					break
 				default:
 					//more than 2 element in the line - means we have a query
 					ui.lookupMode = LOOKUP_MODE_SHOW_SEARCH_RESULTS
-					let searchObject = searchQuery[1]?.toLowerCase()
+					let searchObject = searchQuery[0]?.toLowerCase()
 					ui.loadCompactLayoutIfNeeded(searchObject)
 					break
 			}


### PR DESCRIPTION
Added a new syntax for searching:
?Account Sony 
? Account Sony
    -- Will search for the account containing SONY.  If only one found, will go to that record.   If more than one, will show a dropdown list of records.

Auto complete is available for object names. For example "? ACC" <TAB> will show options like "Account Brand" and "Account Contract"
The fields displayed per record are the same as the compact layout for that record.

I used a smaller font in case of a long text.  not sure I like the result.

other examples:
? Case 123
? contact John
?vendor SONY

