### PR TITLE
Fix extension on my.salesforce-setup.com pages

### DIFF
--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -28,7 +28,7 @@ const getOtherExtensionCommands = (otherExtension, requestDetails, settings = {}
 	let commands = {}
 	if(chrome.management) {
 		chrome.management.get(otherExtension.id, response => {
-			if(chrome.runtime.lastError) { _d("Extension not found", chrome.runtime.lastError); return }
+			if(chrome.runtime.lastError) { _d(["Extension not found", chrome.runtime.lastError]); return }
 			otherExtension.commands.forEach(c=>{
 				commands[c.key] = {
 					"url": otherExtension.platform + "://" + otherExtension.urlId + c.url.replace("$URL",url).replace("$APIURL",apiUrl),

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -83,9 +83,9 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse)=>{
 			break
 		case "getApiSessionId":
 			request.sid = request.uid = request.domain = request.oid = ""
-			chrome.cookies.getAll({}, (all)=>{
+			chrome.cookies.getAll({name: 'sid'}, (all)=>{
 				all.forEach((c)=>{
-					if(c.domain==request.serverUrl && c.name === "sid") {
+					if(c.domain==request.serverUrl) {
 						request.sid = c.value
 						request.domain = c.domain
 						request.oid = request.sid.match(/([\w\d]+)/)[1]

--- a/src/shared.js
+++ b/src/shared.js
@@ -597,7 +597,7 @@ export const forceNavigatorSettings = {
 					forceNavigator.apiUrl = unescape(response.apiUrl)
 					forceNavigator.loadCommands(forceNavigatorSettings)
 				} catch(e) {
-					_d([e, response])
+					_d([e, response, chrome.runtime.lastError])
 				}
 				ui.hideLoadingIndicator()
 			})

--- a/src/shared.js
+++ b/src/shared.js
@@ -915,7 +915,7 @@ export const forceNavigator = {
 		let serverUrl
 		let url = location.origin + ""
 		if(settings.lightningMode) {// if(url.indexOf("lightning.force") != -1)
-			serverUrl = url.replace('lightning.force.com','').replace('my.salesforce.com','') + "lightning.force.com"
+            serverUrl = url.replace(/my\.salesforce\.com$/, 'lightning.force.com').replace(/my\.salesforce-setup\.com$/, 'lightning.force.com')
 		} else {
 			if(url.includes("salesforce"))
 				serverUrl = url.substring(0, url.indexOf("salesforce")) + "salesforce.com"

--- a/src/shared.js
+++ b/src/shared.js
@@ -588,6 +588,7 @@ export const forceNavigatorSettings = {
 			if(forceNavigatorSettings.theme)
 				document.getElementById('sfnavStyleBox').classList = [forceNavigatorSettings.theme]
 			if(forceNavigator.sessionId !== null) { return }
+			if(forceNavigator.serverUrl?.includes('https://test.salesforce.com')) { return }
 			chrome.runtime.sendMessage({ "action": "getApiSessionId", "serverUrl": forceNavigator.serverUrl }, response=>{
 				if(response && response.error) { console.error("response", response, chrome.runtime.lastError); return }
 				try {

--- a/src/shared.js
+++ b/src/shared.js
@@ -668,7 +668,6 @@ export const forceNavigator = {
 		}
 	},
 	"createSObjectCommands": (commands, sObjectData,qualifiedApiNameToDurableIdMap, serverUrl) => {
-        console.log('in createSObjectCommands', qualifiedApiNameToDurableIdMap)
 		const { labelPlural, label, name, keyPrefix } = sObjectData
 		const mapKeys = Object.keys(forceNavigator.objectSetupLabelsMap)
 		if (!keyPrefix || forceNavigatorSettings.skipObjects.includes(keyPrefix)) { return commands }


### PR DESCRIPTION
Hi Danny, recently the extension stopped somehow working on these `my.salesforce-setup.com` pages. I had to re-login and from Home page it worked but once I invoked it from Setup it did not get any information about org, like SObject etc.

This is fix for that, it works by replacing the `my.salesforce-setup.com` with proper `lightning.force.com`. And some improvement for logging and performance I've picked up along the way.

As you did not yet merged the `branch:dev-durableId` to `main` I am creating the PR against this one to see the proper changes in commit history. Feel free to adjust the _base_.