### PR TITLE
Fix extension on my.salesforce-setup.com pages

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -69,6 +69,7 @@
 	"host_permissions": [
 		"https://*.force.com/*",
 		"https://*.salesforce.com/*",
+		"https://*.salesforce-setup.com/*",
 		"https://*.cloudforce.com/*"
 	]
 }

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -84,9 +84,9 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse)=>{
 			break
 		case "getApiSessionId":
 			request.sid = request.uid = request.domain = request.oid = ""
-			chrome.cookies.getAll({}, (all)=>{
+			chrome.cookies.getAll({name: 'sid'}, (all)=>{
 				all.forEach((c)=>{
-					if(c.domain==request.serverUrl && c.name === "sid") {
+					if(c.domain==request.serverUrl) {
 						request.sid = c.value
 						request.domain = c.domain
 						request.oid = request.sid.match(/([\w\d]+)/)[1]

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -28,7 +28,7 @@ const getOtherExtensionCommands = (otherExtension, requestDetails, settings = {}
 	let commands = {}
 	if(chrome.management) {
 		chrome.management.get(otherExtension.id, response => {
-			if(chrome.runtime.lastError) { _d("Extension not found", chrome.runtime.lastError); return }
+			if(chrome.runtime.lastError) { _d(["Extension not found", chrome.runtime.lastError]); return }
 			otherExtension.commands.forEach(c=>{
 				commands[c.key] = {
 					"url": otherExtension.platform + "://" + otherExtension.urlId + c.url.replace("$URL",url).replace("$APIURL",apiUrl),

--- a/src/shared.js
+++ b/src/shared.js
@@ -597,7 +597,7 @@ export const forceNavigatorSettings = {
 					forceNavigator.apiUrl = unescape(response.apiUrl)
 					forceNavigator.loadCommands(forceNavigatorSettings)
 				} catch(e) {
-					_d([e, response])
+					_d([e, response, chrome.runtime.lastError])
 				}
 				ui.hideLoadingIndicator()
 			})

--- a/src/shared.js
+++ b/src/shared.js
@@ -915,7 +915,7 @@ export const forceNavigator = {
 		let serverUrl
 		let url = location.origin + ""
 		if(settings.lightningMode) {// if(url.indexOf("lightning.force") != -1)
-			serverUrl = url.replace('lightning.force.com','').replace('my.salesforce.com','') + "lightning.force.com"
+            serverUrl = url.replace(/my\.salesforce\.com$/, 'lightning.force.com').replace(/my\.salesforce-setup\.com$/, 'lightning.force.com')
 		} else {
 			if(url.includes("salesforce"))
 				serverUrl = url.substring(0, url.indexOf("salesforce")) + "salesforce.com"

--- a/src/shared.js
+++ b/src/shared.js
@@ -588,6 +588,7 @@ export const forceNavigatorSettings = {
 			if(forceNavigatorSettings.theme)
 				document.getElementById('sfnavStyleBox').classList = [forceNavigatorSettings.theme]
 			if(forceNavigator.sessionId !== null) { return }
+			if(forceNavigator.serverUrl?.includes('https://test.salesforce.com')) { return }
 			chrome.runtime.sendMessage({ "action": "getApiSessionId", "serverUrl": forceNavigator.serverUrl }, response=>{
 				if(response && response.error) { console.error("response", response, chrome.runtime.lastError); return }
 				try {


### PR DESCRIPTION
Hi Danny, recently the extension stopped somehow working on these my.salesforce-setup.com pages. I had to re-login and from Home page it worked but once I invoked it from Setup it did not get any information about org, like SObject etc.

This is fix for that, it works by replacing the my.salesforce-setup.com with proper lightning.force.com. And some improvement for logging and performance I've picked up along the way.