### PR TITLE
Use SObject DurableId for Custom Objects

### DIFF
--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -1,4 +1,4 @@
-import { forceNavigator, forceNavigatorSettings, _d } from "./shared"
+import { forceNavigator, _d } from "./shared"
 import { t } from "lisan"
 
 const metaData = {}

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -43,7 +43,6 @@ const getOtherExtensionCommands = (otherExtension, requestDetails, settings = {}
 
 const parseMetadata = (data, url, settings = {}, serverUrl)=>{
 	if (data.length == 0 || typeof data.sobjects == "undefined") return false
-	let mapKeys = Object.keys(forceNavigator.objectSetupLabelsMap)
 	return data.sobjects.reduce((commands, sObjectData) => forceNavigator.createSObjectCommands(commands, sObjectData, serverUrl), {})
 }
 
@@ -103,7 +102,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse)=>{
 						if(request.sid === "") {
 							console.log("No session data found for " + request.serverUrl)
 							sendResponse({error: "No session data found for " + request.serverUrl})
-							return 
+							return
 						}
 						forceNavigator.getHTTP( apiUrl + '/services/data/' + forceNavigator.apiVersion, "json",
 							{"Authorization": "Bearer " + request.sid, "Accept": "application/json"}
@@ -116,13 +115,12 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse)=>{
 						})
 					}
 				)};
-		
+
 			})
 			break
 		case 'getActiveFlows':
 			let flowCommands = {}
-			forceNavigator.getHTTP("https://" + request.apiUrl + '/services/data/' + forceNavigator.apiVersion + '/query/?q=select+ActiveVersionId,Label+from+FlowDefinitionView+where+IsActive=true', "json",
-				{"Authorization": "Bearer " + request.sessionId, "Accept": "application/json"})
+                forceNavigator.getServiceDataHTTP("/query/?q=select+ActiveVersionId,Label+from+FlowDefinitionView+where+IsActive=true", "json", request)
 				.then(response => {
 					let targetUrl = request.domain + "/builder_platform_interaction/flowBuilder.app?flowId="
 					response.records.forEach(f=>{
@@ -137,8 +135,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse)=>{
 			break
 		case 'getMetadata':
 			if(metaData[request.sessionHash] == null || request.force)
-				forceNavigator.getHTTP("https://" + request.apiUrl + '/services/data/' + forceNavigator.apiVersion + '/sobjects/', "json",
-					{"Authorization": "Bearer " + request.sessionId, "Accept": "application/json"})
+                forceNavigator.getServiceDataHTTP("/sobjects/", "json", request)
 					.then(response => {
 						// TODO good place to filter out unwanted objects
 						metaData[request.sessionHash] = parseMetadata(response, request.domain, request.settings, request.serverUrl)
@@ -148,13 +145,11 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse)=>{
 				sendResponse(metaData[request.sessionHash])
 			break
 		case 'createTask':
-			forceNavigator.getHTTP("https://" + request.apiUrl + "/services/data/" + forceNavigator.apiVersion + "/sobjects/Task",
-				"json", {"Authorization": "Bearer " + request.sessionId, "Content-Type": "application/json" },
-				{"Subject": request.subject, "OwnerId": request.userId}, "POST")
+            forceNavigator.getServiceDataHTTP("/sobjects/Task", "json", request, {"Subject": request.subject, "OwnerId": request.userId}, "POST")
 			.then(function (response) { sendResponse(response) })
 			break
 		case 'searchLogins':
-			forceNavigator.getHTTP("https://" + request.apiUrl + "/services/data/" + forceNavigator.apiVersion + "/query/?q=SELECT Id, Name, Username FROM User WHERE Name LIKE '%25" + request.searchValue.trim() + "%25' OR Username LIKE '%25" + request.searchValue.trim() + "%25'", "json", {"Authorization": "Bearer " + request.sessionId, "Content-Type": "application/json" })
+            forceNavigator.getServiceDataHTTP("/query/?q=SELECT Id, Name, Username FROM User WHERE Name LIKE '%25" + request.searchValue.trim() + "%25' OR Username LIKE '%25" + request.searchValue.trim() + "%25'", "json", request)
 			.then(function(success) { sendResponse(success) }).catch(function(error) {
 				console.error(error)
 			})

--- a/src/shared.js
+++ b/src/shared.js
@@ -666,7 +666,8 @@ export const forceNavigator = {
 			_d(e)
 		}
 	},
-	"createSObjectCommands": (commands, sObjectData, serverUrl) => {
+	"createSObjectCommands": (commands, sObjectData,qualifiedApiNameToDurableIdMap, serverUrl) => {
+        console.log('in createSObjectCommands', qualifiedApiNameToDurableIdMap)
 		const { labelPlural, label, name, keyPrefix } = sObjectData
 		const mapKeys = Object.keys(forceNavigator.objectSetupLabelsMap)
 		if (!keyPrefix || forceNavigatorSettings.skipObjects.includes(keyPrefix)) { return commands }
@@ -685,7 +686,7 @@ export const forceNavigator = {
 			"apiname": name
 		}
 		if(forceNavigatorSettings.lightningMode) {
-			let targetUrl = serverUrl + "/lightning/setup/ObjectManager/" + name
+			let targetUrl = serverUrl + "/lightning/setup/ObjectManager/" + (qualifiedApiNameToDurableIdMap[name] ?? name)
 			mapKeys.forEach(key=>{
 				commands[keyPrefix + "." + key] = {
 					"key": keyPrefix + "." + key,
@@ -954,7 +955,7 @@ export const forceNavigator = {
 		})
 	},
     "getServiceDataHTTP" :(endpoint, type = "json", request = {}, data = {}, method = "GET") => {
-        return this.getHTTP(
+        return forceNavigator.getHTTP(
             "https://" + request.apiUrl + '/services/data/' + forceNavigator.apiVersion + endpoint,
             type,
             {"Authorization": "Bearer " + request.sessionId, "Accept": "application/json"},

--- a/src/shared.js
+++ b/src/shared.js
@@ -953,6 +953,15 @@ export const forceNavigator = {
 				return data
 		})
 	},
+    "getServiceDataHTTP" :(endpoint, type = "json", request = {}, data = {}, method = "GET") => {
+        return this.getHTTP(
+            "https://" + request.apiUrl + '/services/data/' + forceNavigator.apiVersion + endpoint,
+            type,
+            {"Authorization": "Bearer " + request.sessionId, "Accept": "application/json"},
+            data,
+            method
+        )
+    },
 	"refreshAndClear": ()=>{
 		ui.showLoadingIndicator()
 		forceNavigator.serverInstance = forceNavigator.getServerInstance(forceNavigator)


### PR DESCRIPTION
This is effectively fix for the [issue 42](https://github.com/dannysummerlin/force-navigator/issues/42). 

With the old build it was not possible to create new fields for custom objects, because the url was not in standard form `/lightning/setup/ObjectManager/CustomObject__c/Details/view` instead of `/lightning/setup/ObjectManager/01IMI000000qSEk/Details/view`. This PR gets the `DurableId` for objects which have populated `EditDefinitionUrl` and uses this in the url instead of name.